### PR TITLE
Status manager

### DIFF
--- a/src/agni/server/AgniServer.java
+++ b/src/agni/server/AgniServer.java
@@ -67,13 +67,13 @@ public class AgniServer {
                                                               infoRequestReceiver,
                                                               heartbeatReceiver);
 
-        LoginManager loginManager = new LoginManager(infoSender, userDataGuard);
+
         UserManager userManager = new UserManager(infoSender, userDataGuard, chatDataGuard);
         ChatManager chatManager = new ChatManager(userDataGuard, chatDataGuard, infoSender, chatSender);
         FileManager fileManager = new FileManager(infoSender, fileSender, fileDataGuard, userDataGuard);
         InfoRequestManager infoRequestManager = new InfoRequestManager(infoSender, heartbeatSender, fileDataGuard);
         StatusManager statusManager = new StatusManager(statusSender, userDataGuard);
-
+        LoginManager loginManager = new LoginManager(infoSender, userDataGuard, statusManager);
         loginReceiver.register(loginManager);
         userReceiver.register(userManager);
         chatReceiver.register(chatManager);

--- a/src/agni/server/AgniServer.java
+++ b/src/agni/server/AgniServer.java
@@ -68,12 +68,13 @@ public class AgniServer {
                                                               heartbeatReceiver);
 
 
-        UserManager userManager = new UserManager(infoSender, userDataGuard, chatDataGuard);
         ChatManager chatManager = new ChatManager(userDataGuard, chatDataGuard, infoSender, chatSender);
         FileManager fileManager = new FileManager(infoSender, fileSender, fileDataGuard, userDataGuard);
         InfoRequestManager infoRequestManager = new InfoRequestManager(infoSender, heartbeatSender, fileDataGuard);
         StatusManager statusManager = new StatusManager(statusSender, userDataGuard);
         LoginManager loginManager = new LoginManager(infoSender, userDataGuard, statusManager);
+        UserManager userManager = new UserManager(infoSender, userDataGuard, chatDataGuard, statusManager);
+        
         loginReceiver.register(loginManager);
         userReceiver.register(userManager);
         chatReceiver.register(chatManager);

--- a/src/agni/server/manager/LoginManager.java
+++ b/src/agni/server/manager/LoginManager.java
@@ -18,11 +18,13 @@ import agni.server.sender.InfoSender;
 public class LoginManager implements LoginListener{
     private InfoSender infoSender;
     private I_UserDataGuard userDataGuard;
+    private StatusManager statusManager; 
 
     public LoginManager(InfoSender infoSender,
-                        UserDataGuard userDataGuard) {
+                        UserDataGuard userDataGuard, StatusManager statusManager) {
         this.infoSender = infoSender;
         this.userDataGuard = userDataGuard;
+        this.statusManager = statusManager;
     }
     private byte [] generateSalt() {
         final Random r = new SecureRandom();
@@ -43,6 +45,7 @@ public class LoginManager implements LoginListener{
             if (generatePasswordHash(password, userDataGuard.salt(user).getBytes()) == userDataGuard.getPasswordHash(user)) {
                 userDataGuard.loginUser(ip, user);
                 infoSender.sendInfo(ip, "approved");
+                statusManager.receiveStatusChange(ip, (byte)0x01);
             }
             else {
                 infoSender.sendInfo(ip, "declined");

--- a/src/agni/server/manager/StatusManager.java
+++ b/src/agni/server/manager/StatusManager.java
@@ -4,10 +4,12 @@ import agni.server.dataguard.I_UserDataGuard;
 import agni.server.dataguard.UserDataGuard;
 import agni.server.receiver.StatusListener;
 import agni.server.sender.StatusSender;
+import agni.server.sender.StatusSender.Status;
 
 public class StatusManager implements StatusListener{
     private StatusSender statusSender;
     private I_UserDataGuard userDataGuard;
+
 
     public StatusManager(StatusSender statusSender,
                          UserDataGuard userDataGuard) {
@@ -17,7 +19,16 @@ public class StatusManager implements StatusListener{
 
     @Override
     public void receiveStatusChange(String ip, byte status) {
-        // TODO Auto-generated method stub
+        String username = userDataGuard.getUsername(ip); 
+    	for (String friend : userDataGuard.getFriends(username)) {
+    		if (status == Status.OFFLINE.bytes()) {
+    			 statusSender.sendStatus(userDataGuard.userCurrentIp(friend), Status.OFFLINE, username);  
+            }
+            else if (status == Status.ONLINE.bytes()) { 
+            	
+            }
+    	}
+        
         
     }
 }

--- a/src/agni/server/manager/StatusManager.java
+++ b/src/agni/server/manager/StatusManager.java
@@ -16,7 +16,7 @@ public class StatusManager implements StatusListener{
     }
 
     @Override
-    public void ReceivedHeartBeat(String ip, byte status) {
+    public void receiveStatusChange(String ip, byte status) {
         // TODO Auto-generated method stub
         
     }

--- a/src/agni/server/manager/StatusManager.java
+++ b/src/agni/server/manager/StatusManager.java
@@ -10,7 +10,6 @@ public class StatusManager implements StatusListener{
     private StatusSender statusSender;
     private I_UserDataGuard userDataGuard;
 
-
     public StatusManager(StatusSender statusSender,
                          UserDataGuard userDataGuard) {
         this.statusSender = statusSender;

--- a/src/agni/server/manager/StatusManager.java
+++ b/src/agni/server/manager/StatusManager.java
@@ -28,7 +28,5 @@ public class StatusManager implements StatusListener{
             	statusSender.sendStatus(userDataGuard.userCurrentIp(friend), Status.ONLINE, username);
             }
     	}
-        
-        
     }
 }

--- a/src/agni/server/manager/StatusManager.java
+++ b/src/agni/server/manager/StatusManager.java
@@ -25,7 +25,7 @@ public class StatusManager implements StatusListener{
     			 statusSender.sendStatus(userDataGuard.userCurrentIp(friend), Status.OFFLINE, username);  
             }
             else if (status == Status.ONLINE.bytes()) { 
-            	
+            	statusSender.sendStatus(userDataGuard.userCurrentIp(friend), Status.ONLINE, username);
             }
     	}
         

--- a/src/agni/server/manager/UserManager.java
+++ b/src/agni/server/manager/UserManager.java
@@ -13,6 +13,7 @@ public class UserManager implements UserListener {
     private InfoSender infoSender;
     private I_UserDataGuard userDataGuard;
     private I_GroupChatDataGuard groupChatDataGuard;
+    private StatusManager statusManager;
 
     public enum UserRequestType {
         JOIN_CHAT((byte) 0x00), 
@@ -35,10 +36,11 @@ public class UserManager implements UserListener {
         }
     }
 
-    public UserManager(InfoSender infoSender, UserDataGuard userDataGuard, GroupChatDataGuard groupChatDataGuard) {
+    public UserManager(InfoSender infoSender, UserDataGuard userDataGuard, GroupChatDataGuard groupChatDataGuard, StatusManager statusManager) {
         this.infoSender = infoSender;
         this.userDataGuard = userDataGuard;
         this.groupChatDataGuard = groupChatDataGuard;
+        this.statusManager = statusManager;
     }
 
     private boolean friendHasAccepted(String username, String friend) {
@@ -138,6 +140,7 @@ public class UserManager implements UserListener {
         else if (type == UserRequestType.LOGOUT.bytes()){       // logout 
             userDataGuard.changeUserCurrentIp(username, null);
             infoSender.sendInfo(ip, "logged out");
+            statusManager.receiveStatusChange(ip, (byte)0x00);
         }
         else if (type == UserRequestType.CREATE_CHAT.bytes()){       // create chat 
             String groupName = argument; 

--- a/src/agni/server/receiver/HeartbeatReceiver.java
+++ b/src/agni/server/receiver/HeartbeatReceiver.java
@@ -12,7 +12,7 @@ public class HeartbeatReceiver implements MessageParser {
 
     private void notifyHeartbeat(String ip, byte status) {
         for ( StatusListener  sListener : statusListeners ) {
-            sListener.ReceivedHeartBeat(ip, status);
+            sListener.receiveStatusChange(ip, status);
         }
     }
 

--- a/src/agni/server/receiver/StatusListener.java
+++ b/src/agni/server/receiver/StatusListener.java
@@ -2,5 +2,5 @@ package agni.server.receiver;
 
 public interface StatusListener {
 
-    public void ReceivedHeartBeat (String ip, byte status);
+    public void receiveStatusChange (String ip, byte status);
 }

--- a/src/test/agni/server/receiver/HeartBeatReceiverTest.java
+++ b/src/test/agni/server/receiver/HeartBeatReceiverTest.java
@@ -54,7 +54,7 @@ public class HeartBeatReceiverTest {
     @Test
     public void correctInputTest() {
         context.checking(new Expectations() {{
-            oneOf(mockStatusListener).ReceivedHeartBeat("192.168.1.1", testStatus);
+            oneOf(mockStatusListener).receiveStatusChange("192.168.1.1", testStatus);
         }});
         hbReceiver.receiveMessage(testIp, bufferArray);
         context.assertIsSatisfied();
@@ -65,7 +65,7 @@ public class HeartBeatReceiverTest {
     public void nullIpTest() {
         context.checking(new Expectations() {{
             final String expectedIp = "192.168.1.1";
-            oneOf(mockStatusListener).ReceivedHeartBeat(expectedIp, testStatus);
+            oneOf(mockStatusListener).receiveStatusChange(expectedIp, testStatus);
         }});
         hbReceiver.receiveMessage(null, bufferArray);
         context.assertIsSatisfied();
@@ -75,7 +75,7 @@ public class HeartBeatReceiverTest {
     public void nullMessageTest() {
         context.checking(new Expectations() {{
             final String expectedIp = "192.168.1.1";
-            oneOf(mockStatusListener).ReceivedHeartBeat(expectedIp, testStatus);
+            oneOf(mockStatusListener).receiveStatusChange(expectedIp, testStatus);
         }});
         hbReceiver.receiveMessage(testIp, null);
         context.assertIsSatisfied();


### PR DESCRIPTION
Implemented status manager to deal with the status sender to notify friends whether a user has went online or offline. 

I passed in a status manager into the login manager (that keeps track of when a user successfully logs in) and also in the user manager (which keeps track of when a user logs out) so that these functionalities can trigger status changes to be sent to a user's friends. 

It will need to be implemented later on that when a client times out and disconnects, the user's friends should also be notified that the user went offline. This will be done in the HeartbeatManager that checks if a client has timed out. (See issue #73)
